### PR TITLE
Add support for NFS

### DIFF
--- a/overlayRoot.sh
+++ b/overlayRoot.sh
@@ -21,7 +21,8 @@
 #  Created 2017 by Pascal Suter @ DALCO AG, Switzerland to work on Raspian as custom init script
 #  (raspbian does not use an initramfs on boot)
 #  Update 1.2 ~ 1.4 by fitu996@github
-#  Update 1.5 by LeosDing@github
+#  Update 1.5 by LeosDing@github review&modified by fitu996@github
+#  Update 1.6 by mad-jrodriguez@github review&modified by fitu996@github
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -75,22 +76,10 @@ fail(){
             exit 1
         fi
 }
-
-search_nfs_rootfs_info(){
-    local file="$1"
-    get_rootfs_info_in_file "/etc/mtab"
-    nfs="`echo $rootFsType | grep "nfs"`"
-    if [ ! -z "$rootDev" ] && [ ! -z "$nfs" ]; then
-        return 0
-    fi
-    return 1
-}
-
-get_rootfs_info_in_file(){
-    local file="$1"
-    rootDev="`grep -v -x -E '^(#.*)|([[:space:]]*)$' "$file" | awk '$2 == "/" {print $1}'`"
-    rootMountOpt="`grep -v -x -E '^(#.*)|([[:space:]]*)$' "$file" | awk '$2 == "/" {print $4}'`"
-    rootFsType="`grep -v -x -E '^(#.*)|([[:space:]]*)$' "$file" | awk '$2 == "/" {print $3}'`"
+grep_mnt(){
+    grep -v -x -E '^(#.*)|([[:space:]]*)$' /etc/fstab || :
+    grep -v -x -E '^(#.*)|([[:space:]]*)$' /etc/mtab || :
+    grep -v -x -E '^(#.*)|([[:space:]]*)$' /proc/self/mounts || :
 }
 
 # mount /proc
@@ -133,16 +122,15 @@ mkdir /mnt/overlay/upper
 mkdir /mnt/overlay/work
 mkdir /mnt/newroot
 write_log 6 "find rootfs informations."
-
-if ! search_nfs_rootfs_info ; then
-    get_rootfs_info_in_file "/etc/fstab"
-    write_log 6 "check if we can locate the root device based on fstab"
+rootDev="`grep_mnt | awk '$2 == "/" {print $1;exit}'`"
+rootMountOpt="`grep_mnt | awk '$2 == "/" {print $4;exit}'`"
+rootFsType="`grep_mnt | awk '$2 == "/" {print $3;exit}'`"
+write_log 6 "check if we can locate the root device from fstab and mtab"
+if blkid "$rootDev"; then
+    :
+elif printf '%s\n' "$rootFsType" | grep -q -F -e nfs -e nfs4 -e cifs -e ramfs -e tmpfs -e smbfs -e ncpfs -e virtiofs -e 9p ; then
+    :
 else
-    write_log 6 "NFS root found. rootDev: $rootDev fsType: $rootFsType"
-    nfsFound=1
-fi
-
-if [ $nfsFound -ne 1 ] && [ ! blkid $rootDev ] ; then
     write_log 5 "root device in fstab is not block device file"
     write_log 6 "try if fstab contains a LABEL definition"
     rootDevFstab="$rootDev"


### PR DESCRIPTION
Hi!

I modified your script for running remote stateless machines using iPXE. Previous versions only were designed to run locally however, I needed to run the script on remote machines where the rootfs were mounted with NFS. I tested it with several linux distributions such as ubuntu 20, ubuntu 22, ubuntu 24, debian 11, debian 12, fedora 40 and rhel 9.x and works as expected on all of them.

Besides, I tested on a local virtual machine that works locally as well.

The changes are quite simple, just check first on /etc/mtab if "/" is mounted with NFS. If so, just fill $rootDev, $rootMountOpt and $rootFsType variables and continue the execution. If not, continue the "legacy" path.

 I would like to add these changes if you consider them useful.

Regards,

Javier R.